### PR TITLE
Add extra coverage for lamp object

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,7 +40,8 @@ import { DeviceSingleComponent } from 'app/components/device-single/device-singl
 import { DocsComponent } from '@components/docs/docs.component';
 import { DocsApiWorkaroundComponent } from '@components/docs/docs-api-workaround/docs-api-workaround.component';
 import { DeviceGeneralInformationComponent } from 'app/components/device-general-information/device-general-information.component';
-import { DeviceCustomizationComponent } from 'app/components/device-customization/device-customization.component';
+import { DeviceTemperatureComponent } from '@app/components/device-temperature/device-temperature.component';
+import { DeviceLampComponent } from '@app/components/device-lamp/device-lamp.component';
 import { StatisticsComponent } from '@components/statistics/statistics.component';
 import { environment } from '../environments/environment';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
@@ -107,8 +108,6 @@ export class AppComponent {
   }
 }
 
-
-
 @NgModule({
   declarations: [
     AppComponent,
@@ -134,7 +133,8 @@ export class AppComponent {
     LocationSingleComponent,
     OutputPinViewComponent,
     NavigationComponent,
-    DeviceCustomizationComponent,
+    DeviceTemperatureComponent,
+    DeviceLampComponent,
     SwitchWidgetsComponent,
     IconWidgetsComponent,
     PlacesComponent,

--- a/src/app/components/device-general-information/device-general-information.component.html
+++ b/src/app/components/device-general-information/device-general-information.component.html
@@ -22,6 +22,7 @@
             <label class="input select">
                 <select class="form-control app-device-general-type" [(ngModel)]="form.type" (ngModelChange)="SubmitChange()">
                     <option value="0" translate>Temperature sensor</option>
+                    <option value="1" translate>Single Bridge Lamp</option>
                 </select>
                 <i></i>
             </label>

--- a/src/app/components/device-lamp/device-lamp.component.html
+++ b/src/app/components/device-lamp/device-lamp.component.html
@@ -1,0 +1,10 @@
+<app-page-container maintitle="Lamp Customization" subtitle="Modify how a lamp can look and feel among dashboard">
+  <div class="row">
+    <div class="col-md-12">
+      <label class="checkbox" >
+        <input type="checkbox" class="app-device-customization-realtime" (change)="TriggerChange();" [(ngModel)]="form.DisplayLampOnOffInHome">
+        <i></i> <span translate>Display the real time value in home page</span>
+      </label>
+    </div>  
+  </div>
+</app-page-container>

--- a/src/app/components/device-lamp/device-lamp.component.ts
+++ b/src/app/components/device-lamp/device-lamp.component.ts
@@ -1,0 +1,21 @@
+import { Component, Output, EventEmitter, Input } from '@angular/core';
+import { IDeviceDisplayPreference } from '@app/definitions';
+
+@Component({
+  selector: 'app-device-lamp',
+  templateUrl: './device-lamp.component.html',
+  styleUrls: ['./device-lamp.component.scss']
+})
+export class DeviceLampComponent {
+
+  public form: IDeviceDisplayPreference = {};
+  @Output('onChange') public onChange: EventEmitter<IDeviceDisplayPreference> = new EventEmitter();
+  @Input('preferences') public set preferences (value:  IDeviceDisplayPreference) {
+    this.form = Object.assign({}, value) || {};
+  }
+
+  public TriggerChange () {
+    this.onChange.emit(this.form);
+  }
+
+}

--- a/src/app/components/device-single/device-single.component.html
+++ b/src/app/components/device-single/device-single.component.html
@@ -6,7 +6,17 @@
 
   <app-device-general-information [response]="response" [mode]="form.id ? 'edit': 'new'" [device]="form" 
     (onChange)="DeviceGeneralChange($event)" ></app-device-general-information>
-  <app-device-customization [preferences]="form.preferences" (onChange)="DeviceCustomizationChange($event)"></app-device-customization>  
+
+    <app-device-temperature
+    *ngIf="IsTemperature()"
+    [preferences]="form.preferences" 
+    (onChange)="DeviceCustomizationChange($event)">
+  </app-device-temperature>
+  <app-device-lamp
+    *ngIf="IsLamp()"
+    [preferences]="form.preferences" 
+    (onChange)="DeviceCustomizationChange($event)">
+  </app-device-lamp>
   
   <button (click)="SubmitForm()" translate class="btn btn-primary app-device-single-edit" *ngIf="form.id">Edit device</button>
   <button (click)="DeleteDevice()" translate class="btn btn-danger" *ngIf="form.id">Delete device</button>

--- a/src/app/components/device-single/device-single.component.ts
+++ b/src/app/components/device-single/device-single.component.ts
@@ -60,6 +60,12 @@ export class DeviceSingleComponent implements OnInit, OnDestroy {
   ngOnDestroy () {
 
   }
+  public IsTemperature () {
+    return +this.form.type === CloudDeviceType.TemperatureSensor;
+  }
+  public IsLamp () {
+    return +this.form.type === CloudDeviceType.LampBridge;
+  }
   
   public async SubmitForm () {
     delete this.form.value;

--- a/src/app/components/device-temperature/device-temperature.component.html
+++ b/src/app/components/device-temperature/device-temperature.component.html
@@ -1,4 +1,4 @@
-<app-page-container maintitle="Device Customization" subtitle="Modify how a device can look and feel among dashboard">
+<app-page-container maintitle="Lamp Customization" subtitle="Modify how a temperature can look and feel among dashboard">
   <div class="row">
     <div class="col-md-12">
       <label class="checkbox" >

--- a/src/app/components/device-temperature/device-temperature.component.ts
+++ b/src/app/components/device-temperature/device-temperature.component.ts
@@ -2,11 +2,11 @@ import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
 import { IDeviceDisplayPreference } from '@app/definitions';
 
 @Component({
-  selector: 'app-device-customization',
-  templateUrl: './device-customization.component.html',
-  styleUrls: ['./device-customization.component.scss']
+  selector: 'app-device-temperature',
+  templateUrl: './device-temperature.component.html',
+  styleUrls: ['./device-temperature.component.scss']
 })
-export class DeviceCustomizationComponent implements OnInit {
+export class DeviceTemperatureComponent implements OnInit {
 
   public form: IDeviceDisplayPreference = {};
   @Output('onChange') public onChange: EventEmitter<IDeviceDisplayPreference> = new EventEmitter();

--- a/src/app/components/index/index.component.html
+++ b/src/app/components/index/index.component.html
@@ -6,12 +6,12 @@
 <div class="row">
   <ng-container *ngFor="let device of devices">
     <ng-container *ngIf="device.preferences">
-        <div class="col-xl-4 col-lg-6 col-md-4 col-sm-6" *ngIf="device.preferences.DisplayRealTimeTemperatureInSidebar">
+        <div class="col-xl-4 col-lg-6 col-md-4 col-sm-6" *ngIf="device.preferences.DisplayRealTimeTemperatureInSidebar && +device.type === 0">
           <div class="box-wrapper">
             <app-daily-statistics [id]="device.id"></app-daily-statistics>
           </div>
         </div>
-        <div class="col-xl-4 col-lg-6 col-md-4 col-sm-6" *ngIf="device.preferences.DisplayLampOnOffInHome">
+        <div class="col-xl-4 col-lg-6 col-md-4 col-sm-6" *ngIf="device.preferences.DisplayLampOnOffInHome && +device.type === 1">
           <div class="box-wrapper">
             <app-lamp-card [id]="device.id"></app-lamp-card>
           </div>

--- a/src/environments/environment.hmr.ts
+++ b/src/environments/environment.hmr.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  production: false,
+  production: true,
   hmr: true,
   api: 'http://localhost:1337'
 };

--- a/src/environments/environment.hmr.ts
+++ b/src/environments/environment.hmr.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  production: true,
+  production: false,
   hmr: true,
   api: 'http://localhost:1337'
 };


### PR DESCRIPTION
Add more coverage for lamp module. Now you can create a lamp, and also display inside the dashboard. Device customization is renamed to temperature, and for each different type of the module we will have a different component to make it's configuration.